### PR TITLE
Add crew GACC selection via CLI

### DIFF
--- a/BranchAndPrice.jl
+++ b/BranchAndPrice.jl
@@ -230,14 +230,15 @@ function price_and_cut!!!!(
 end
 
 function branch_and_price(
-	num_fires::Int,
-	num_crews::Int,
-	num_time_periods::Int;
-	current_time = 0,
-	from_empirical = false,
-	line_per_crew = 20,
-	travel_speed = 640.0,
-	max_nodes = 10000,
+        num_fires::Int,
+        num_crews::Int,
+        num_time_periods::Int;
+        current_time = 0,
+        from_empirical = false,
+        gaccs = ["Great Basin"],
+        line_per_crew = 20,
+        travel_speed = 640.0,
+        max_nodes = 10000,
 	algo_tracking = false,
 	branching_strategy = "linking_dual_max_variance",
 	cut_search_enumeration_limit = 10000,
@@ -264,8 +265,8 @@ function branch_and_price(
 	crew_routes = nothing,
 	fire_plans = nothing, 
 	crew_models  = nothing,
-	fire_models = nothing,
-	cut_data  = nothing,
+        fire_models = nothing,
+        cut_data  = nothing,
 )
 	start_time = time()
 	root_node_ip_sol = 0.0
@@ -274,8 +275,8 @@ function branch_and_price(
 	if crew_routes === nothing
 		@info "Initializing data structures"
 		# initialize input data
-		@time crew_routes, fire_plans, crew_models, fire_models, cut_data =
-			initialize_data_structures(num_fires, num_crews, num_time_periods, line_per_crew, travel_speed, from_empirical = from_empirical)
+                @time crew_routes, fire_plans, crew_models, fire_models, cut_data =
+                        initialize_data_structures(num_fires, num_crews, num_time_periods, line_per_crew, travel_speed, from_empirical = from_empirical, gaccs = gaccs)
 		GC.gc()
 		algo_tracking ?
 		(@info "Checkpoint after initializing data structures" time() - start_time) :
@@ -543,14 +544,15 @@ function branch_and_price(
 end
 
 function initialize_data_structures(
-	num_fires::Int64,
-	num_crews::Int64,
-	num_time_periods::Int64,
-	line_per_crew::Int64,
-	travel_speed::Float64;
-	from_empirical = false
+        num_fires::Int64,
+        num_crews::Int64,
+        num_time_periods::Int64,
+        line_per_crew::Int64,
+        travel_speed::Float64;
+        from_empirical = false,
+        gaccs = ["Great Basin"],
 )
-	if !from_empirical
+        if !from_empirical
 		crew_models = build_crew_models(
 			"data/raw/big_fire",
 			num_fires,
@@ -567,13 +569,13 @@ function initialize_data_structures(
 			line_per_crew
 		)
 	else
-		crew_models = build_crew_models_from_empirical(
-			num_crews, num_fires, num_time_periods, travel_speed
-		)
-		fire_models = build_fire_models_from_empirical(
-			num_fires, num_crews, num_time_periods
-		)
-	end
+                crew_models = build_crew_models_from_empirical(
+                        num_crews, num_fires, num_time_periods, travel_speed; gaccs = gaccs
+                )
+                fire_models = build_fire_models_from_empirical(
+                        num_fires, num_crews, num_time_periods; gaccs = gaccs
+                )
+        end
 
 
 	crew_routes = CrewRouteData(Int(floor(6 * 1e6 / num_crews)), num_fires, num_crews, num_time_periods)

--- a/TSNetworkGeneration.jl
+++ b/TSNetworkGeneration.jl
@@ -471,19 +471,20 @@ function get_rest_penalties(
 end
 
 function build_crew_models_from_empirical(
-    num_crews::Int64, 
-    num_fires::Int64, 
+    num_crews::Int64,
+    num_fires::Int64,
     num_time_periods::Int64,
     travel_speed::Float64,
-    travel_fixed_delay::Int64 = 0,
+    travel_fixed_delay::Int64 = 0;
+    gaccs::Vector{String} = ["Great Basin"],
 )
 
     # read in the selected fires
     fire_folder = "data/empirical_fire_models/raw/arc_arrays"
     selected_fires = CSV.read(fire_folder * "/" * "selected_fires.csv", DataFrame) 
 
-    # restrict to the fires that are in the GACC "Great Basin"
-    selected_fires = selected_fires[selected_fires[:, "GACC"] .== "Great Basin", :]
+    # restrict to fires in the desired GACCs
+    selected_fires = selected_fires[in.(selected_fires[:, "GACC"], Ref(gaccs)), :]
 
     # sort these by "start_day_of_sim" and then by "FIRE_EVENT_ID"
     selected_fires = sort(selected_fires, [:start_day_of_sim, :FIRE_EVENT_ID])
@@ -497,8 +498,8 @@ function build_crew_models_from_empirical(
     # read in the crew locations
     tau_base_to_fire = CSV.read(fire_folder * "/../" * "base_fire_distances.csv", DataFrame)
 
-    # restrict to the crews that are in GACC "Great Basin"
-    tau_base_to_fire = tau_base_to_fire[tau_base_to_fire[:, "GACC"] .== "Great Basin", :]
+    # restrict to crews in the desired GACCs
+    tau_base_to_fire = tau_base_to_fire[in.(tau_base_to_fire[:, "GACC"], Ref(gaccs)), :]
 
     # restrict to the fires whose fire_id is in the arc_file column of "selected_fires.csv"
     tau_base_to_fire = tau_base_to_fire[findall(in(selected_fires[idx, "FIRE_EVENT_ID"]), tau_base_to_fire[:, "fire_id"]), :]
@@ -1229,9 +1230,10 @@ function build_fire_models(
 end
 
 function build_fire_models_from_empirical(
-    num_fires::Int64, 
-    num_crews::Int64, 
-    num_time_periods::Int64,
+    num_fires::Int64,
+    num_crews::Int64,
+    num_time_periods::Int64;
+    gaccs::Vector{String} = ["Great Basin"],
 )
 
     # initialize fire models
@@ -1249,8 +1251,8 @@ function build_fire_models_from_empirical(
     fire_folder = "data/empirical_fire_models/raw/arc_arrays"
     selected_fires = CSV.read(fire_folder * "/" * "selected_fires.csv", DataFrame)
 
-    # restrict to the fires that are in the GACC "Great Basin"
-    selected_fires = selected_fires[selected_fires[:, "GACC"] .== "Great Basin", :]
+    # restrict to the fires that are in the desired GACCs
+    selected_fires = selected_fires[in.(selected_fires[:, "GACC"], Ref(gaccs)), :]
 
     # sort these by "start_day_of_sim" and then by "FIRE_EVENT_ID"
     selected_fires = sort(selected_fires, [:start_day_of_sim, :FIRE_EVENT_ID])


### PR DESCRIPTION
## Summary
- Allow EmpiricalMain to accept `--crew-gaccs` CLI argument for selecting crew GACCs
- Propagate GACC filtering through branch-and-price initialization
- Filter crew and fire datasets by selected GACCs when building empirical models

## Testing
- `julia --project=package_dependencies/julia test/test_DCG.jl` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899e57d5e8083308fa94f70535ef125