### PR TITLE
Allow configurable firefighters per crew

### DIFF
--- a/BranchAndPrice.jl
+++ b/BranchAndPrice.jl
@@ -543,12 +543,12 @@ function branch_and_price(
 end
 
 function initialize_data_structures(
-	num_fires::Int64,
-	num_crews::Int64,
-	num_time_periods::Int64,
-	line_per_crew::Int64,
-	travel_speed::Float64;
-	from_empirical = false
+        num_fires::Int64,
+        num_crews::Int64,
+        num_time_periods::Int64,
+        personnel_per_crew::Int64,
+        travel_speed::Float64;
+        from_empirical = false
 )
 	if !from_empirical
 		crew_models = build_crew_models(
@@ -559,21 +559,21 @@ function initialize_data_structures(
 			travel_speed,
 		)
 
-		fire_models = build_fire_models(
-			"data/raw/big_fire",
-			num_fires,
-			num_crews,
-			num_time_periods,
-			line_per_crew
-		)
-	else
-		crew_models = build_crew_models_from_empirical(
-			num_crews, num_fires, num_time_periods, travel_speed
-		)
-		fire_models = build_fire_models_from_empirical(
-			num_fires, num_crews, num_time_periods
-		)
-	end
+                fire_models = build_fire_models(
+                        "data/raw/big_fire",
+                        num_fires,
+                        num_crews,
+                        num_time_periods,
+                        personnel_per_crew,
+                )
+        else
+                crew_models = build_crew_models_from_empirical(
+                        num_crews, num_fires, num_time_periods, travel_speed, personnel_per_crew
+                )
+                fire_models = build_fire_models_from_empirical(
+                        num_fires, num_crews, num_time_periods, personnel_per_crew
+                )
+        end
 
 
 	crew_routes = CrewRouteData(Int(floor(6 * 1e6 / num_crews)), num_fires, num_crews, num_time_periods)

--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -6,13 +6,17 @@ const GRB_ENV = Gurobi.Env()
 
 
 function get_command_line_args()
-	arg_parse_settings = ArgParseSettings()
-	@add_arg_table arg_parse_settings begin
-		"--debug"
-		help = "run in debug mode, exposing all logging that uses @debug macro"
-		action = :store_true
-	end
-	return parse_args(arg_parse_settings)
+        arg_parse_settings = ArgParseSettings()
+        @add_arg_table arg_parse_settings begin
+                "--debug"
+                help = "run in debug mode, exposing all logging that uses @debug macro"
+                action = :store_true
+                "--crew-size"
+                help = "number of firefighters in each crew"
+                arg_type = Int
+                default = 70
+        end
+        return parse_args(arg_parse_settings)
 end
 
 
@@ -32,13 +36,20 @@ if args["debug"] == true
 else
 	global_logger(ConsoleLogger(io, Logging.Info, show_limited = false))
 end
-num_fires = 14	
+num_fires = 14
 num_crews = 12
 num_time_periods = 14
 travel_speed = 40.0 * 6.0
 GC.gc()
 
-crew_routes, fire_plans, crew_models, fire_models, cut_data = initialize_data_structures(num_fires, num_crews, num_time_periods, 20, travel_speed, from_empirical = true)
+crew_routes, fire_plans, crew_models, fire_models, cut_data = initialize_data_structures(
+        num_fires,
+        num_crews,
+        num_time_periods,
+        args["crew_size"],
+        travel_speed,
+        from_empirical = true,
+)
 for j in 1:num_crews
 	no_fire_anticipation!(crew_models[j], [fsp.start_time_period for fsp in fire_models])
 end

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Edit [`EmpiricalMain.jl`](EmpiricalMain.jl) to modify run parameters:
 
 * `num_fires`, `num_crews`, and `num_time_periods` control the size of the case study.
 * `travel_speed = 40.0 * 6.0` encodes a 40 mph average speed for 6 hours of travel per day. Change the second factor to adjust allowed daily travel time.
-* The fourth argument to `initialize_data_structures` is the number of personnel per crew (e.g., change `20` to `70`).
+* Use the `--crew-size` flag in `EmpiricalMain.jl` to control the number of personnel per crew (defaults to `70`).
 
 Save the file and rerun the script to evaluate the new settings.
 

--- a/TSNetworkGeneration.jl
+++ b/TSNetworkGeneration.jl
@@ -471,10 +471,11 @@ function get_rest_penalties(
 end
 
 function build_crew_models_from_empirical(
-    num_crews::Int64, 
-    num_fires::Int64, 
+    num_crews::Int64,
+    num_fires::Int64,
     num_time_periods::Int64,
     travel_speed::Float64,
+    personnel_per_crew::Int64,
     travel_fixed_delay::Int64 = 0,
 )
 
@@ -583,8 +584,8 @@ function build_crew_models_from_empirical(
     fires_start_day = selected_fires[idx, "start_day_of_sim"]
     active_fires = findall(fires_start_day .== 0)
 
-    # since each crew is 20 people, we can divide by 20 to get the number of crews
-    type_1_crews = round.(Int, type_1_crews / 20)
+    # divide by the number of personnel per crew to get crew counts
+    type_1_crews = round.(Int, type_1_crews / personnel_per_crew)
 
     # but if the fire is not active at day 0, we set the number of crews to 0
     for i in 1:num_fires
@@ -1229,9 +1230,10 @@ function build_fire_models(
 end
 
 function build_fire_models_from_empirical(
-    num_fires::Int64, 
-    num_crews::Int64, 
+    num_fires::Int64,
+    num_crews::Int64,
     num_time_periods::Int64,
+    personnel_per_crew::Int64,
 )
 
     # initialize fire models
@@ -1263,8 +1265,8 @@ function build_fire_models_from_empirical(
         fname = selected_fires[fire, "arc_file"]
         arc_array = readdlm(fire_folder * "/" * fname, ',')
 
-        # divide the last column by 20 (number of personnel per crew)
-        arc_array[:, end] = arc_array[:, end] / 20
+        # convert personnel counts to crews
+        arc_array[:, end] = arc_array[:, end] / personnel_per_crew
 
         # cast to integer, rounding to nearest
         arc_array = convert(Array{Int64}, round.(arc_array))


### PR DESCRIPTION
## Summary
- Allow EmpiricalMain to accept a `--crew-size` argument (default 70)
- Pass crew size through initialization and empirical model builders
- Document `--crew-size` usage in README

## Testing
- `julia --project=. test/test_TSNetworkGeneration.jl` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899e58c57b08330ac80659e46e87249