### PR TITLE
Allow configurable crew size in EmpiricalMain

### DIFF
--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -43,6 +43,10 @@ function get_command_line_args()
                 "--crew-gaccs"
                 help = "Allowed crew GACCs: 'all', 'all_no_ak', or comma-separated list of abbreviations (e.g. GB,NW)"
                 default = "GB"
+                "--firefighters-per-crew"
+                help = "Number of firefighters per crew"
+                arg_type = Int
+                default = 70
         end
         return parse_args(arg_parse_settings)
 end
@@ -50,6 +54,7 @@ end
 
 args = get_command_line_args()
 crew_gaccs = parse_gaccs(args["crew-gaccs"])
+firefighters_per_crew = args["firefighters-per-crew"]
 
 io = open("logs_precompile_5.txt", "w")
 if args["debug"] == true
@@ -71,7 +76,7 @@ num_time_periods = 14
 travel_speed = 40.0 * 6.0
 GC.gc()
 
-crew_routes, fire_plans, crew_models, fire_models, cut_data = initialize_data_structures(num_fires, num_crews, num_time_periods, 20, travel_speed, from_empirical = true, gaccs = crew_gaccs)
+crew_routes, fire_plans, crew_models, fire_models, cut_data = initialize_data_structures(num_fires, num_crews, num_time_periods, firefighters_per_crew, travel_speed, from_empirical = true, gaccs = crew_gaccs)
 for j in 1:num_crews
 	no_fire_anticipation!(crew_models[j], [fsp.start_time_period for fsp in fire_models])
 end

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ An optional `--debug` flag can be passed to expose verbose logging:
 julia --project=package_dependencies/julia EmpiricalMain.jl --debug
 ```
 
+Use `--firefighters-per-crew` to control the number of personnel assigned to each crew (default `70`):
+
+```bash
+julia --project=package_dependencies/julia EmpiricalMain.jl --firefighters-per-crew 20
+```
+
 The run produces JSON files describing crew and fire arcs in `data/output/` and writes `selected_fires_sorted.csv` to `data/empirical_fire_models/raw/arc_arrays/` for visualization.
 
 ## 4. Preparing data for new case studies
@@ -69,7 +75,7 @@ Edit [`EmpiricalMain.jl`](EmpiricalMain.jl) to modify run parameters:
 
 * `num_fires`, `num_crews`, and `num_time_periods` control the size of the case study.
 * `travel_speed = 40.0 * 6.0` encodes a 40 mph average speed for 6 hours of travel per day. Change the second factor to adjust allowed daily travel time.
-* The fourth argument to `initialize_data_structures` is the number of personnel per crew (e.g., change `20` to `70`).
+* Pass `--firefighters-per-crew` to set the number of personnel per crew (default `70`).
 
 Save the file and rerun the script to evaluate the new settings.
 


### PR DESCRIPTION
## Summary
- Add `--firefighters-per-crew` argument to EmpiricalMain with default 70
- Document new crew-size option in README

## Testing
- `julia --project=package_dependencies/julia -e 'using Pkg; Pkg.instantiate(); Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6899e83db4b08330826d37fc3c870d27