### PR TITLE
Handle crew counts for inactive fires

### DIFF
--- a/TSNetworkGeneration.jl
+++ b/TSNetworkGeneration.jl
@@ -594,7 +594,7 @@ function build_crew_models_from_empirical(
                 a = type_1_crews[i]
                 @warn "Fire $i is not active at day 0, setting type_1_crews to 0 from $a"
             end
-            # type_1_crews[i] = 0
+            type_1_crews[i] = 0
         end
     end
 


### PR DESCRIPTION
## Summary
- Zero out crew counts for fires that aren't active on day 0 to avoid exceeding available crews

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899f5e06fb48330a4c1d7725e300162