### PR TITLE
Fix GACC abbreviation lookup

### DIFF
--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -30,7 +30,7 @@ function parse_gaccs(str::String)
                 return filter(!=("Alaska"), ALL_GACCS)
         else
                 abbrs = split(s, ",")
-                return [get(GACC_ABBR, a, error("Unknown GACC abbreviation: $a")) for a in abbrs]
+                return [haskey(GACC_ABBR, a) ? GACC_ABBR[a] : error("Unknown GACC abbreviation: $a") for a in abbrs]
         end
 end
 


### PR DESCRIPTION
## Summary
- avoid eager evaluation of error when parsing GACC abbreviations

## Testing
- `julia --project=package_dependencies/julia EmpiricalMain.jl --crew-gaccs=GB,NW` *(fails: `julia` command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899f60244f4833084c61e2b9a36bc82