### PR TITLE
Expose configurable crew size with default 70

### DIFF
--- a/BranchAndPrice.jl
+++ b/BranchAndPrice.jl
@@ -237,9 +237,10 @@ function branch_and_price(
         from_empirical = false,
         gaccs = ["Great Basin"],
         line_per_crew = 20,
+        firefighters_per_crew = 70,
         travel_speed = 640.0,
         max_nodes = 10000,
-	algo_tracking = false,
+        algo_tracking = false,
 	branching_strategy = "linking_dual_max_variance",
 	cut_search_enumeration_limit = 10000,
 	cut_loop_max = 10,
@@ -272,11 +273,20 @@ function branch_and_price(
 	root_node_ip_sol = 0.0
 	root_node_ip_sol_time = 0.0
 
-	if crew_routes === nothing
-		@info "Initializing data structures"
-		# initialize input data
+        if crew_routes === nothing
+                @info "Initializing data structures"
+                # initialize input data
                 @time crew_routes, fire_plans, crew_models, fire_models, cut_data =
-                        initialize_data_structures(num_fires, num_crews, num_time_periods, line_per_crew, travel_speed, from_empirical = from_empirical, gaccs = gaccs)
+                        initialize_data_structures(
+                                num_fires,
+                                num_crews,
+                                num_time_periods,
+                                line_per_crew,
+                                travel_speed,
+                                from_empirical = from_empirical,
+                                gaccs = gaccs,
+                                firefighters_per_crew = firefighters_per_crew,
+                        )
 		GC.gc()
 		algo_tracking ?
 		(@info "Checkpoint after initializing data structures" time() - start_time) :
@@ -551,6 +561,7 @@ function initialize_data_structures(
         travel_speed::Float64;
         from_empirical = false,
         gaccs = ["Great Basin"],
+        firefighters_per_crew::Int64 = 70,
 )
         if !from_empirical
 		crew_models = build_crew_models(
@@ -570,10 +581,14 @@ function initialize_data_structures(
 		)
 	else
                 crew_models = build_crew_models_from_empirical(
-                        num_crews, num_fires, num_time_periods, travel_speed; gaccs = gaccs
+                        num_crews, num_fires, num_time_periods, travel_speed;
+                        gaccs = gaccs,
+                        firefighters_per_crew = firefighters_per_crew,
                 )
                 fire_models = build_fire_models_from_empirical(
-                        num_fires, num_crews, num_time_periods; gaccs = gaccs
+                        num_fires, num_crews, num_time_periods;
+                        gaccs = gaccs,
+                        firefighters_per_crew = firefighters_per_crew,
                 )
         end
 

--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -76,7 +76,16 @@ num_time_periods = 14
 travel_speed = 40.0 * 6.0
 GC.gc()
 
-crew_routes, fire_plans, crew_models, fire_models, cut_data = initialize_data_structures(num_fires, num_crews, num_time_periods, firefighters_per_crew, travel_speed, from_empirical = true, gaccs = crew_gaccs)
+crew_routes, fire_plans, crew_models, fire_models, cut_data = initialize_data_structures(
+        num_fires,
+        num_crews,
+        num_time_periods,
+        firefighters_per_crew,
+        travel_speed,
+        from_empirical = true,
+        gaccs = crew_gaccs,
+        firefighters_per_crew = firefighters_per_crew,
+)
 for j in 1:num_crews
 	no_fire_anticipation!(crew_models[j], [fsp.start_time_period for fsp in fire_models])
 end
@@ -108,12 +117,13 @@ for t in 0:14
                 from_empirical = true,
                 gaccs = crew_gaccs,
                 travel_speed = travel_speed,
+                firefighters_per_crew = firefighters_per_crew,
                 crew_routes = crew_routes,
                 fire_plans = fire_plans,
                 crew_models = crew_models,
                 fire_models = fire_models,
-		cut_data = cut_data
-		)
+                cut_data = cut_data
+                )
 		# Unpack as many variables as branch_and_price returns, e.g.:
 	explored_nodes, ubs, lbs, columns, heuristic_times, times, time_1, root_node_ip_sol, root_node_ip_sol_time, fire_arcs_used, crew_arcs_used = result
 	@info "final arcs used" fire_arcs_used, crew_arcs_used

--- a/TSNetworkGeneration.jl
+++ b/TSNetworkGeneration.jl
@@ -477,6 +477,7 @@ function build_crew_models_from_empirical(
     travel_speed::Float64,
     travel_fixed_delay::Int64 = 0;
     gaccs::Vector{String} = ["Great Basin"],
+    firefighters_per_crew::Int64 = 70,
 )
 
     # read in the selected fires
@@ -584,8 +585,8 @@ function build_crew_models_from_empirical(
     fires_start_day = selected_fires[idx, "start_day_of_sim"]
     active_fires = findall(fires_start_day .== 0)
 
-    # since each crew is 20 people, we can divide by 20 to get the number of crews
-    type_1_crews = round.(Int, type_1_crews / 20)
+    # convert personnel counts to crew counts using the crew size
+    type_1_crews = round.(Int, type_1_crews / firefighters_per_crew)
 
     # but if the fire is not active at day 0, we set the number of crews to 0
     for i in 1:num_fires
@@ -1234,6 +1235,7 @@ function build_fire_models_from_empirical(
     num_crews::Int64,
     num_time_periods::Int64;
     gaccs::Vector{String} = ["Great Basin"],
+    firefighters_per_crew::Int64 = 70,
 )
 
     # initialize fire models
@@ -1265,8 +1267,8 @@ function build_fire_models_from_empirical(
         fname = selected_fires[fire, "arc_file"]
         arc_array = readdlm(fire_folder * "/" * fname, ',')
 
-        # divide the last column by 20 (number of personnel per crew)
-        arc_array[:, end] = arc_array[:, end] / 20
+        # convert personnel counts to crew counts using crew size
+        arc_array[:, end] = arc_array[:, end] / firefighters_per_crew
 
         # cast to integer, rounding to nearest
         arc_array = convert(Array{Int64}, round.(arc_array))


### PR DESCRIPTION
## Summary
- Allow specifying number of firefighters per crew across the system with a default of 70.
- Use crew size parameter when generating empirical crew and fire networks.
- Plumb crew size argument through branch-and-price initialization.

## Testing
- `julia --project=package_dependencies/julia test/test_TSNetworkGeneration.jl` *(failed: command not found)*
- `apt-get update` *(failed: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6899fb6d1e188330a2c66ff84532024b