### PR TITLE
Improve startup logging for empirical run

### DIFF
--- a/BranchAndPrice.jl
+++ b/BranchAndPrice.jl
@@ -276,7 +276,7 @@ function branch_and_price(
         if crew_routes === nothing
                 @info "Initializing data structures"
                 # initialize input data
-                @time crew_routes, fire_plans, crew_models, fire_models, cut_data =
+                @time crew_routes, fire_plans, crew_models, fire_models, cut_data, _ =
                         initialize_data_structures(
                                 num_fires,
                                 num_crews,
@@ -564,23 +564,24 @@ function initialize_data_structures(
         firefighters_per_crew::Int64 = 70,
 )
         if !from_empirical
-		crew_models = build_crew_models(
-			"data/raw/big_fire",
-			num_fires,
-			num_crews,
-			num_time_periods,
-			travel_speed,
-		)
+                crew_models = build_crew_models(
+                        "data/raw/big_fire",
+                        num_fires,
+                        num_crews,
+                        num_time_periods,
+                        travel_speed,
+                )
 
-		fire_models = build_fire_models(
-			"data/raw/big_fire",
-			num_fires,
-			num_crews,
-			num_time_periods,
-			line_per_crew
-		)
-	else
-                crew_models = build_crew_models_from_empirical(
+                fire_models = build_fire_models(
+                        "data/raw/big_fire",
+                        num_fires,
+                        num_crews,
+                        num_time_periods,
+                        line_per_crew
+                )
+                info = nothing
+        else
+                crew_models, info = build_crew_models_from_empirical(
                         num_crews, num_fires, num_time_periods, travel_speed;
                         gaccs = gaccs,
                         firefighters_per_crew = firefighters_per_crew,
@@ -597,7 +598,7 @@ function initialize_data_structures(
 	fire_plans = FirePlanData(Int(floor(6 * 1e6  / num_crews)), num_fires, num_time_periods)
 	cut_data = CutData(num_crews, num_fires, num_time_periods)
 
-	return crew_routes, fire_plans, crew_models, fire_models, cut_data
+        return crew_routes, fire_plans, crew_models, fire_models, cut_data, info
 end
 
 # TODO if this is a bottleneck, can cache lower bounds

--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -56,6 +56,10 @@ args = get_command_line_args()
 crew_gaccs = parse_gaccs(args["crew-gaccs"])
 firefighters_per_crew = args["firefighters-per-crew"]
 
+@info "Arguments" args
+@info "Crew GACCs" crew_gaccs
+@info "Firefighters per crew" firefighters_per_crew
+
 io = open("logs_precompile_5.txt", "w")
 if args["debug"] == true
 	global_logger(ConsoleLogger(io, Logging.Debug, show_limited = false))
@@ -76,7 +80,7 @@ num_time_periods = 14
 travel_speed = 40.0 * 6.0
 GC.gc()
 
-crew_routes, fire_plans, crew_models, fire_models, cut_data = initialize_data_structures(
+crew_routes, fire_plans, crew_models, fire_models, cut_data, init_info = initialize_data_structures(
         num_fires,
         num_crews,
         num_time_periods,
@@ -86,6 +90,18 @@ crew_routes, fire_plans, crew_models, fire_models, cut_data = initialize_data_st
         gaccs = crew_gaccs,
         firefighters_per_crew = firefighters_per_crew,
 )
+
+@info "Total crews" num_crews
+@info "Fire selection criterion" init_info.selection
+for (ix, fire_id) in enumerate(init_info.fire_ids)
+        start_day = init_info.start_days[ix]
+        crew_list = findall(==(ix), init_info.crew_assignments)
+        @info "Using fire" ix "id" fire_id "start_day" start_day "initial_crews" crew_list
+end
+unassigned_crews = findall(==( -1 ), init_info.crew_assignments)
+if !isempty(unassigned_crews)
+        @info "Crews initially without fire assignment" unassigned_crews
+end
 for j in 1:num_crews
 	no_fire_anticipation!(crew_models[j], [fsp.start_time_period for fsp in fire_models])
 end

--- a/TSNetworkGeneration.jl
+++ b/TSNetworkGeneration.jl
@@ -482,7 +482,7 @@ function build_crew_models_from_empirical(
 
     # read in the selected fires
     fire_folder = "data/empirical_fire_models/raw/arc_arrays"
-    selected_fires = CSV.read(fire_folder * "/" * "selected_fires.csv", DataFrame) 
+    selected_fires = CSV.read(fire_folder * "/" * "selected_fires.csv", DataFrame)
 
     # restrict to fires in the desired GACCs
     selected_fires = selected_fires[in.(selected_fires[:, "GACC"], Ref(gaccs)), :]
@@ -493,8 +493,10 @@ function build_crew_models_from_empirical(
     # write out these sorted fires to a new file with only the columns we need
     CSV.write(fire_folder * "/" * "selected_fires_sorted.csv", selected_fires[:, [:FIRE_EVENT_ID, :start_day_of_sim]])
 
-    # get the unique fire ids
+    # get the unique fire ids and their start days
     idx = unique(i -> selected_fires[i, "FIRE_EVENT_ID"], eachindex(selected_fires[:, "FIRE_EVENT_ID"]))
+    fire_ids = selected_fires[idx, "FIRE_EVENT_ID"]
+    fire_start_days = selected_fires[idx, "start_day_of_sim"]
 
     # read in the crew locations
     tau_base_to_fire = CSV.read(fire_folder * "/../" * "base_fire_distances.csv", DataFrame)
@@ -733,7 +735,15 @@ function build_crew_models_from_empirical(
         push!(crew_sps, crew_sp)
     end
 
-    return crew_sps
+    info = (
+        fire_ids = fire_ids,
+        start_days = fire_start_days,
+        crew_assignments = current_fire,
+        crews_per_fire = type_1_crews,
+        selection = "Filtered to GACCs $(join(gaccs, ",")) and sorted by start_day_of_sim then FIRE_EVENT_ID"
+    )
+
+    return crew_sps, info
 end
 
 

--- a/experiments/problem_size.jl
+++ b/experiments/problem_size.jl
@@ -32,14 +32,14 @@ sizes = [
 
 l = []
 for (num_fires, num_crews, num_time_periods, line_per_crew, travel_speed) in sizes
-	_, _, crew_models, fire_models, _ =
-		initialize_data_structures(
-			num_fires,
-			num_crews,
-			num_time_periods,
-			line_per_crew,
-			travel_speed,
-		)
+        _, _, crew_models, fire_models, _, _ =
+                initialize_data_structures(
+                        num_fires,
+                        num_crews,
+                        num_time_periods,
+                        line_per_crew,
+                        travel_speed,
+                )
     GC.gc()
 	d = Dict{Any, Any}("crews" => num_crews, "fires" => num_fires)
 	num_crew_arcs = [size(crew_models[i].wide_arcs)[2] for i in 1:num_crews]


### PR DESCRIPTION
## Summary
- Log command-line arguments and crew GACCs at program start
- Describe fire selection criteria and print per-fire IDs and initial crew assignments
- Return initialization metadata to support detailed logging

## Testing
- `julia --project=package_dependencies/julia test/test_DCG.jl` *(failed: bash: command not found: julia)*
- `apt-get update` *(failed: repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a03ced4b883308d69ab8a8c18973a