### PR TITLE
Improve logging of initialization details

### DIFF
--- a/BranchAndPrice.jl
+++ b/BranchAndPrice.jl
@@ -473,17 +473,18 @@ function branch_and_price(
 end
 
 function initialize_data_structures(
-	num_fires::Int64,
-	num_crews::Int64,
-	num_time_periods::Int64,
-	line_per_crew::Int64,
-	travel_speed::Float64
+        num_fires::Int64,
+        num_crews::Int64,
+        num_time_periods::Int64,
+        line_per_crew::Int64,
+        travel_speed::Float64
 )
-	crew_models = build_crew_models(
-		"data/raw/big_fire",
-		num_fires,
-		num_crews,
-		num_time_periods,
+        @info "Fires included in optimization" collect(1:num_fires)
+        crew_models = build_crew_models(
+                "data/raw/big_fire",
+                num_fires,
+                num_crews,
+                num_time_periods,
 		travel_speed,
 	)
 

--- a/TSNetworkGeneration.jl
+++ b/TSNetworkGeneration.jl
@@ -317,6 +317,8 @@ function crew_data_from_path(path, travel_speed::Float64)
     # (-1 in current_fire means crew is currently at base)
     # (rested_periods is the amount of time crew has been at base, relevant for completing rest)
     crew_starts = CSV.read(path * "/sample_crew_starts.csv", DataFrame)
+    allocation = combine(groupby(crew_starts, :current_fire), nrow => :count)
+    @info "Initial crew allocation" allocation
     rest_by = crew_starts[!, "rest_by"]
     current_fire = crew_starts[!, "current_fire"]
     rested_periods = crew_starts[!, "rested_periods"]


### PR DESCRIPTION
## Summary
- Log list of fires included in optimization during data structure initialization
- Report initial crew allocation counts when reading crew data

## Testing
- Attempted to run `julia --project=package_dependencies/julia test/test_TSNetworkGeneration.jl` *(command not found)*
- Attempted `apt-get update` to install Julia *(403 errors from repositories)*

------
https://chatgpt.com/codex/tasks/task_e_689a0c40b2d483309c70a96ce7b6116b