### PR TITLE
Compute crew count from GACC selection

### DIFF
--- a/BranchAndPrice.jl
+++ b/BranchAndPrice.jl
@@ -585,11 +585,12 @@ function initialize_data_structures(
                 info = nothing
         else
                 crew_models, info = build_crew_models_from_empirical(
-                        num_crews, num_fires, num_time_periods, travel_speed;
+                        num_fires, num_time_periods, travel_speed;
                         gaccs = gaccs,
                         firefighters_per_crew = firefighters_per_crew,
                         fires_by_gacc = fires_by_gacc,
                 )
+                num_crews = length(crew_models)
                 fire_models = build_fire_models_from_empirical(
                         num_fires, num_crews, num_time_periods;
                         gaccs = gaccs,

--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -97,8 +97,8 @@ if args["debug"] == true
 else
 	global_logger(ConsoleLogger(io, Logging.Info, show_limited = false))
 end
-num_fires = 14	
-num_crews = 12
+num_fires = 14
+num_crews = 0
 num_time_periods = 14
 travel_speed = 40.0 * 6.0
 GC.gc()
@@ -114,6 +114,8 @@ crew_routes, fire_plans, crew_models, fire_models, cut_data, init_info = initial
         firefighters_per_crew = firefighters_per_crew,
         fires_by_gacc = fires_by_gacc,
 )
+
+num_crews = length(crew_models)
 
 @info "Total crews" num_crews
 @info "Fire selection criterion" init_info.selection

--- a/TSNetworkGeneration.jl
+++ b/TSNetworkGeneration.jl
@@ -471,7 +471,6 @@ function get_rest_penalties(
 end
 
 function build_crew_models_from_empirical(
-    num_crews::Int64,
     num_fires::Int64,
     num_time_periods::Int64,
     travel_speed::Float64,
@@ -536,6 +535,9 @@ function build_crew_models_from_empirical(
 
     # transpose the matrix so that the rows are the crews and the columns are the fires
     tau_base_to_fire = copy(tau_base_to_fire')
+
+    # determine number of crews from the data
+    num_crews = size(tau_base_to_fire, 1)
 
     # minutes to days
     tau_base_to_fire = tau_base_to_fire / 60 / 24


### PR DESCRIPTION
## Summary
- derive crew count from base-to-fire data instead of hard-coding
- propagate dynamic crew count through initialization and main entry point

## Testing
- `julia --project=package_dependencies/julia -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a4b0bcde88330ba96dd8d1e72af0a