### PR TITLE
Fix logging references in empirical driver

### DIFF
--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -1,16 +1,17 @@
 include("BranchAndPrice.jl")
 
 using JuMP, Gurobi, JSON, Profile, ArgParse, Logging, IterTools
+import Logging: min_enabled_level, shouldlog, handle_message
 
 struct DualLogger <: AbstractLogger
         loggers::NTuple{2,AbstractLogger}
 end
 
-Base.min_enabled_level(l::DualLogger) = min(min_enabled_level(l.loggers[1]), min_enabled_level(l.loggers[2]))
-Base.shouldlog(l::DualLogger, level, _module, group, id) =
+min_enabled_level(l::DualLogger) = min(min_enabled_level(l.loggers[1]), min_enabled_level(l.loggers[2]))
+shouldlog(l::DualLogger, level, _module, group, id) =
         shouldlog(l.loggers[1], level, _module, group, id) ||
         shouldlog(l.loggers[2], level, _module, group, id)
-Base.handle_message(l::DualLogger, level, message, _module, group, id, file, line) = begin
+handle_message(l::DualLogger, level, message, _module, group, id, file, line) = begin
         handle_message(l.loggers[1], level, message, _module, group, id, file, line)
         handle_message(l.loggers[2], level, message, _module, group, id, file, line)
 end


### PR DESCRIPTION
## Summary
- use Logging's min_enabled_level/shouldlog/handle_message for DualLogger

## Testing
- `julia --project=package_dependencies/julia EmpiricalMain.jl --crew-gaccs=GB,NW` *(fails: command not found: julia)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a4d7011c483309ac10012ecf5dc2b