### PR TITLE
Support kwargs in DualLogger logging

### DIFF
--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -11,9 +11,9 @@ min_enabled_level(l::DualLogger) = min(min_enabled_level(l.loggers[1]), min_enab
 shouldlog(l::DualLogger, level, _module, group, id) =
         shouldlog(l.loggers[1], level, _module, group, id) ||
         shouldlog(l.loggers[2], level, _module, group, id)
-handle_message(l::DualLogger, level, message, _module, group, id, file, line) = begin
-        handle_message(l.loggers[1], level, message, _module, group, id, file, line)
-        handle_message(l.loggers[2], level, message, _module, group, id, file, line)
+handle_message(l::DualLogger, level, message, _module, group, id, file, line; kwargs...) = begin
+        handle_message(l.loggers[1], level, message, _module, group, id, file, line; kwargs...)
+        handle_message(l.loggers[2], level, message, _module, group, id, file, line; kwargs...)
 end
 
 const GRB_ENV = Gurobi.Env()


### PR DESCRIPTION
## Summary
- allow DualLogger to forward keyword arguments to its underlying loggers

## Testing
- `julia --project=package_dependencies/julia test/test_DCG.jl` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `curl -L -o /tmp/julia.tar.gz https://julialang-s3.julialang.org/bin/linux/x64/1.11/julia-1.11.0-linux-x86_64.tar.gz` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_689a4f1559a08330be830d8a9f82b986