### PR TITLE
feat: allow configurable output folder

### DIFF
--- a/BranchAndPrice.jl
+++ b/BranchAndPrice.jl
@@ -241,6 +241,7 @@ function branch_and_price(
         firefighters_per_crew = 70,
         travel_speed = 640.0,
         fires_by_gacc::Dict{String,Vector{Int64}} = Dict{String,Vector{Int64}}(),
+        output_folder = "data/output",
         max_nodes = 10000,
         algo_tracking = false,
 	branching_strategy = "linking_dual_max_variance",
@@ -473,8 +474,8 @@ function branch_and_price(
 				fire_plans,
 			)
 
-			# if it is not a directory, make the directory data/output
-			isdir("data/output") || mkdir("data/output")
+                        # ensure the output directory exists
+                        isdir(output_folder) || mkpath(output_folder)
 
 			# extract the arc data from the subproblems
 			for fire in 1:num_fires
@@ -484,8 +485,8 @@ function branch_and_price(
 				restricted_costs = fire_models[fire].arc_costs[arcs_used]
 				# remove the first column, which is extraneous
 				restricted_long_arcs = restricted_long_arcs[:, 2:end]
-				NPZ.npzwrite("data/output/fire_$(fire)_arcs.npy", restricted_long_arcs)
-				NPZ.npzwrite("data/output/fire_$(fire)_costs.npy", restricted_costs)
+                                NPZ.npzwrite(joinpath(output_folder, "fire_$(fire)_arcs.npy"), restricted_long_arcs)
+                                NPZ.npzwrite(joinpath(output_folder, "fire_$(fire)_costs.npy"), restricted_costs)
 			end
 
 			for crew in 1:num_crews
@@ -495,8 +496,8 @@ function branch_and_price(
 				# remove the first column, which is extraneous
 				restricted_long_arcs = restricted_long_arcs[:, 2:end]
 				restricted_costs = crew_models[crew].arc_costs[arcs_used]
-				NPZ.npzwrite("data/output/crew_$(crew)_arcs.npy", restricted_long_arcs)
-				NPZ.npzwrite("data/output/crew_$(crew)_costs.npy", restricted_costs)
+                                NPZ.npzwrite(joinpath(output_folder, "crew_$(crew)_arcs.npy"), restricted_long_arcs)
+                                NPZ.npzwrite(joinpath(output_folder, "crew_$(crew)_costs.npy"), restricted_costs)
 			end
 
 			@info "new incumbent" fire_allots crew_allots fire_cost crew_cost fire_arcs_used crew_arcs_used

--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -105,6 +105,9 @@ function get_command_line_args()
                 help = "Time limit in seconds for the branch-and-price algorithm"
                 arg_type = Float64
                 default = 1800.0
+                "--output-folder"
+                help = "Directory to store output files"
+                default = "data/output"
         end
         return parse_args(arg_parse_settings)
 end
@@ -116,6 +119,8 @@ fire_gaccs = isempty(args["fire-gaccs"]) ? crew_gaccs : parse_gaccs(args["fire-g
 firefighters_per_crew = args["firefighters-per-crew"]
 fires_by_gacc = parse_fires_by_gacc(args["fires"])
 time_limit = args["time-limit"]
+output_folder = args["output-folder"]
+mkpath(output_folder)
 
 # send logs to both console and file so users can see initialization details
 log_file = open("logs_$(Int(time_limit)).txt", "w")
@@ -212,6 +217,7 @@ for t in 0:14
                 fire_models = fire_models,
                 cut_data = cut_data,
                 total_time_limit = time_limit,
+                output_folder = output_folder,
                 )
                 # Unpack as many variables as branch_and_price returns, e.g.:
         explored_nodes, ubs, lbs, columns, heuristic_times, times, time_1, root_node_ip_sol, root_node_ip_sol_time, fire_arcs_used, crew_arcs_used = result
@@ -246,20 +252,20 @@ for t in 0:14
 		crew_arc_costs[j] = crew_models[j].arc_costs[reverse(crew_arcs_used[j])]
 	end
 
-	# write these to files
-	for g in 1:num_fires
-		open("data/output/fire_arcs_$(g)_$(t).json", "w") do io
-			JSON.print(io, fire_arcs[g])
-		end
-		open("data/output/fire_arc_costs_$(g)_$(t).json", "w") do io
-			JSON.print(io, fire_arc_costs[g])
-		end
-	end
+        # write these to files
+        for g in 1:num_fires
+                open(joinpath(output_folder, "fire_arcs_$(g)_$(t).json"), "w") do io
+                        JSON.print(io, fire_arcs[g])
+                end
+                open(joinpath(output_folder, "fire_arc_costs_$(g)_$(t).json"), "w") do io
+                        JSON.print(io, fire_arc_costs[g])
+                end
+        end
         for j in 1:num_crews
-                open("data/output/crew_arcs_$(j)_$(t).json", "w") do io
+                open(joinpath(output_folder, "crew_arcs_$(j)_$(t).json"), "w") do io
                         JSON.print(io, crew_arcs[j])
                 end
-                open("data/output/crew_arc_costs_$(j)_$(t).json", "w") do io
+                open(joinpath(output_folder, "crew_arc_costs_$(j)_$(t).json"), "w") do io
                         JSON.print(io, crew_arc_costs[j])
                 end
         end

--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ Use `--firefighters-per-crew` to control the number of personnel assigned to eac
 julia --project=package_dependencies/julia EmpiricalMain.jl --firefighters-per-crew 20
 ```
 
-The run produces JSON files describing crew and fire arcs in `data/output/` and writes `selected_fires_sorted.csv` to `data/empirical_fire_models/raw/arc_arrays/` for visualization.
+Use `--output-folder` to choose where JSON outputs are written (defaults to `data/output/`):
+
+```bash
+julia --project=package_dependencies/julia EmpiricalMain.jl --output-folder my_results
+```
+
+The run produces JSON files describing crew and fire arcs in the specified output directory and writes `selected_fires_sorted.csv` to `data/empirical_fire_models/raw/arc_arrays/` for visualization.
 
 ## 4. Preparing data for new case studies
 
@@ -81,7 +87,7 @@ Save the file and rerun the script to evaluate the new settings.
 
 ## 6. Output
 
-Each invocation writes arc information for every fire and crew to JSON files in `data/output/` with filenames of the form `fire_arcs_<fire>_<time>.json`, `fire_arc_costs_<fire>_<time>.json`, `crew_arcs_<crew>_<time>.json`, and `crew_arc_costs_<crew>_<time>.json`.
+Each invocation writes arc information for every fire and crew to JSON files in the chosen output directory (default `data/output/`) with filenames of the form `fire_arcs_<fire>_<time>.json`, `fire_arc_costs_<fire>_<time>.json`, `crew_arcs_<crew>_<time>.json`, and `crew_arc_costs_<crew>_<time>.json`.
 
 ## 7. Repeating experiments
 


### PR DESCRIPTION
## Summary
- add `--output-folder` flag to EmpiricalMain for configurable output directory
- propagate output folder into branch_and_price and write all output files there
- document the new flag in README

## Testing
- `julia --project=package_dependencies/julia -e 'using Pkg; Pkg.test()'` (fails: command not found)
- `apt-get update` (fails: repository not signed/403)


------
https://chatgpt.com/codex/tasks/task_e_689a6217bb4883309d12372852745b5c