### PR TITLE
Parameterize initial crew size

### DIFF
--- a/BranchAndPrice.jl
+++ b/BranchAndPrice.jl
@@ -239,6 +239,7 @@ function branch_and_price(
         fire_gaccs = gaccs,
         line_per_crew = 20,
         firefighters_per_crew = 70,
+        initial_firefighters_per_crew = 20,
         travel_speed = 640.0,
         fires_by_gacc::Dict{String,Vector{Int64}} = Dict{String,Vector{Int64}}(),
         output_folder = "data/output",
@@ -291,6 +292,7 @@ function branch_and_price(
                                 crew_gaccs = gaccs,
                                 fire_gaccs = fire_gaccs,
                                 firefighters_per_crew = firefighters_per_crew,
+                                initial_firefighters_per_crew = initial_firefighters_per_crew,
                                 fires_by_gacc = fires_by_gacc,
                         )
 		GC.gc()
@@ -569,6 +571,7 @@ function initialize_data_structures(
         crew_gaccs = ["Great Basin"],
         fire_gaccs = crew_gaccs,
         firefighters_per_crew::Int64 = 70,
+        initial_firefighters_per_crew::Int64 = 20,
         fires_by_gacc::Dict{String,Vector{Int64}} = Dict{String,Vector{Int64}}(),
 )
         if !from_empirical
@@ -594,6 +597,7 @@ function initialize_data_structures(
                         crew_gaccs = crew_gaccs,
                         fire_gaccs = fire_gaccs,
                         firefighters_per_crew = firefighters_per_crew,
+                        initial_firefighters_per_crew = initial_firefighters_per_crew,
                         fires_by_gacc = fires_by_gacc,
                 )
                 num_crews = length(crew_models)

--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -98,6 +98,10 @@ function get_command_line_args()
                 help = "Number of firefighters per crew"
                 arg_type = Int
                 default = 70
+                "--personnel-per-crew"
+                help = "Personnel count representing one crew when initializing from empirical data"
+                arg_type = Int
+                default = 20
                 "--fires"
                 help = "Mapping of GACC abbreviations to comma-separated FIRE_EVENT_IDs, separated by semicolons (e.g. GB:1,2;NW:3)"
                 default = ""
@@ -117,6 +121,7 @@ args = get_command_line_args()
 crew_gaccs = parse_gaccs(args["crew-gaccs"])
 fire_gaccs = isempty(args["fire-gaccs"]) ? crew_gaccs : parse_gaccs(args["fire-gaccs"])
 firefighters_per_crew = args["firefighters-per-crew"]
+personnel_per_crew = args["personnel-per-crew"]
 fires_by_gacc = parse_fires_by_gacc(args["fires"])
 time_limit = args["time-limit"]
 output_folder = args["output-folder"]
@@ -138,6 +143,7 @@ global_logger(DualLogger((console_logger, file_logger)))
 @info "Crew GACCs" crew_gaccs
 @info "Fire GACCs" fire_gaccs
 @info "Firefighters per crew" firefighters_per_crew
+@info "Personnel per crew" personnel_per_crew
 @info "Total time limit" time_limit
 
 num_fires = count_selected_fires(fire_gaccs, fires_by_gacc)
@@ -157,6 +163,7 @@ crew_routes, fire_plans, crew_models, fire_models, cut_data, init_info = initial
         crew_gaccs = crew_gaccs,
         fire_gaccs = fire_gaccs,
         firefighters_per_crew = firefighters_per_crew,
+        initial_firefighters_per_crew = personnel_per_crew,
         fires_by_gacc = fires_by_gacc,
 )
 
@@ -210,6 +217,7 @@ for t in 0:14
                 fire_gaccs = fire_gaccs,
                 travel_speed = travel_speed,
                 firefighters_per_crew = firefighters_per_crew,
+                initial_firefighters_per_crew = personnel_per_crew,
                 fires_by_gacc = fires_by_gacc,
                 crew_routes = crew_routes,
                 fire_plans = fire_plans,

--- a/TSNetworkGeneration.jl
+++ b/TSNetworkGeneration.jl
@@ -478,6 +478,7 @@ function build_crew_models_from_empirical(
     crew_gaccs::Vector{String} = ["Great Basin"],
     fire_gaccs::Vector{String} = crew_gaccs,
     firefighters_per_crew::Int64 = 70,
+    initial_firefighters_per_crew::Int64 = 20,
     fires_by_gacc::Dict{String,Vector{Int64}} = Dict{String,Vector{Int64}}(),
 )
 
@@ -601,8 +602,8 @@ function build_crew_models_from_empirical(
     fires_start_day = selected_fires[idx, "start_day_of_sim"]
     active_fires = findall(fires_start_day .== 0)
 
-    # convert personnel counts to crew counts using the crew size
-    type_1_crews = round.(Int, type_1_crews / firefighters_per_crew)
+    # convert personnel counts to crew counts using the initial crew size
+    type_1_crews = round.(Int, type_1_crews / initial_firefighters_per_crew)
 
     # but if the fire is not active at day 0, we set the number of crews to 0
     for i in 1:num_fires


### PR DESCRIPTION
## Summary
- Allow specifying personnel per crew when initializing empirical data
- Keep existing firefighters-per-crew parameter for fire models
- Wire new argument through command line and model initialization

## Testing
- `julia --project=package_dependencies/julia test/test_TSNetworkGeneration.jl` *(fails: command not found: julia)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a840fa27483308b4ab235b5dbf9a7