### PR TITLE
Read distance files from input folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ All raw data files live in `data/empirical_fire_models/raw/arc_arrays/`. To run 
 * **Fire and base distances**
   * `fire_fire_distances.csv` – pairwise distances between fires.
   * `base_fire_distances.csv` – distances from each crew base to each fire.
+  * Place both files in the same directory passed via `--input-folder`.
 * **Selected fires**
   * `selected_fires.csv` – list of fires to include. After a run, the script produces `selected_fires_sorted.csv` in the same folder.
 * **Arc descriptions and costs**

--- a/TSNetworkGeneration.jl
+++ b/TSNetworkGeneration.jl
@@ -511,7 +511,7 @@ function build_crew_models_from_empirical(
     fire_start_days = selected_fires[idx, "start_day_of_sim"]
 
     # read in the crew locations
-    tau_base_to_fire = CSV.read(fire_folder * "/../" * "base_fire_distances.csv", DataFrame)
+    tau_base_to_fire = CSV.read(fire_folder * "/" * "base_fire_distances.csv", DataFrame)
 
     # restrict to crews in the desired GACCs
     tau_base_to_fire = tau_base_to_fire[in.(tau_base_to_fire[:, "GACC"], Ref(crew_gaccs)), :]
@@ -564,7 +564,7 @@ function build_crew_models_from_empirical(
 
     # TODO fix fire-distances
     # for now they will all be the same
-    raw_fire_dists = CSV.read(fire_folder * "/../" * "fire_to_fire_distances.csv", DataFrame)
+    raw_fire_dists = CSV.read(fire_folder * "/" * "fire_to_fire_distances.csv", DataFrame)
     dict_fire_dists = Dict()
     for row in eachrow(raw_fire_dists)
         dict_fire_dists[row["fire1_id"], row["fire2_id"]] = row["duration_min"] 


### PR DESCRIPTION
## Summary
- Load `base_fire_distances.csv` and `fire_to_fire_distances.csv` directly from the input folder instead of its parent
- Clarify README that distance files must reside alongside other input data

## Testing
- `julia --project=package_dependencies/julia test/test_TSNetworkGeneration.jl` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3902fde0483309398dca404b7dcbf