### PR TITLE
feat: allow flexible input folder path

### DIFF
--- a/EmpiricalMain.jl
+++ b/EmpiricalMain.jl
@@ -85,6 +85,24 @@ function count_selected_fires(
         return length(unique(selected_fires[:, "FIRE_EVENT_ID"]))
 end
 
+function resolve_input_folder(folder::String)
+        # if the provided path already points to a folder with selected_fires.csv, use it
+        if isfile(joinpath(folder, "selected_fires.csv"))
+                return folder
+        end
+        # check for an arc_arrays subdirectory
+        arc_path = joinpath(folder, "arc_arrays")
+        if isfile(joinpath(arc_path, "selected_fires.csv"))
+                return arc_path
+        end
+        # otherwise look relative to data/empirical_fire_models
+        candidate = joinpath("data", "empirical_fire_models", folder, "arc_arrays")
+        if isfile(joinpath(candidate, "selected_fires.csv"))
+                return candidate
+        end
+        error("Input folder $folder not found or missing selected_fires.csv")
+end
+
 function get_command_line_args()
         arg_parse_settings = ArgParseSettings()
         @add_arg_table arg_parse_settings begin
@@ -113,8 +131,8 @@ function get_command_line_args()
                 arg_type = Float64
                 default = 1800.0
                 "--input-folder"
-                help = "Directory containing input files"
-                default = "data/empirical_fire_models/raw/arc_arrays"
+                help = "Directory containing input files (full path or dataset under data/empirical_fire_models)"
+                default = "raw"
                 "--output-folder"
                 help = "Directory to store output files"
                 default = "data/output"
@@ -130,7 +148,7 @@ firefighters_per_crew = args["firefighters-per-crew"]
 personnel_per_crew = args["personnel-per-crew"]
 fires_by_gacc = parse_fires_by_gacc(args["fires"])
 time_limit = args["time-limit"]
-input_folder = args["input-folder"]
+input_folder = resolve_input_folder(args["input-folder"])
 output_folder = args["output-folder"]
 mkpath(output_folder)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Use `--firefighters-per-crew` to control the number of personnel assigned to eac
 julia --project=package_dependencies/julia EmpiricalMain.jl --firefighters-per-crew 20
 ```
 
-Use `--input-folder` to choose where the script looks for input CSV files (defaults to `data/empirical_fire_models/raw/arc_arrays/`):
+Use `--input-folder` to choose where the script looks for input CSV files. You can pass either a full path or the name of a dataset under `data/empirical_fire_models` (defaults to `raw` which resolves to `data/empirical_fire_models/raw/arc_arrays/`):
 
 ```bash
 julia --project=package_dependencies/julia EmpiricalMain.jl --input-folder my_inputs
@@ -79,11 +79,11 @@ Use `--crew-gaccs` and `--fire-gaccs` to restrict crews and fires by Geographic 
 
 Convenience options are also available: `all` includes every GACC, while `all_no_ak` includes all of them except Alaska.
 
-The run produces JSON files describing crew and fire arcs in the specified output directory and writes `selected_fires_sorted.csv` to `data/empirical_fire_models/raw/arc_arrays/` for visualization.
+The run produces JSON files describing crew and fire arcs in the specified output directory and writes `selected_fires_sorted.csv` to the resolved input folder for visualization.
 
 ## 4. Preparing data for new case studies
 
-All raw data files live in `data/empirical_fire_models/raw/arc_arrays/`. To run a new experiment, replace or augment the following files:
+By default, raw data files live in `data/empirical_fire_models/raw/arc_arrays/`. To run a new experiment, place the following files in the directory passed via `--input-folder` and replace or augment them as needed:
 
 * **Fire and base distances**
   * `fire_fire_distances.csv` – pairwise distances between fires.
@@ -95,7 +95,7 @@ All raw data files live in `data/empirical_fire_models/raw/arc_arrays/`. To run 
   * `arc_arrays_*.csv` – one file per fire containing the state transition arcs. The filename should follow `arc_arrays_<NIFCID>_<FIRENAME>_day0.csv`.
   * `arc_costs_*.csv` – cost of each arc, matched to the corresponding `arc_arrays_*` file: `arc_costs_<NIFCID>_<FIRENAME>_day0.csv`.
 
-Place each new CSV in `data/empirical_fire_models/raw/arc_arrays/` using the same naming pattern. The program automatically loads every `arc_arrays_*.csv` and `arc_costs_*.csv` present.
+Place each new CSV in that input directory using the same naming pattern. The program automatically loads every `arc_arrays_*.csv` and `arc_costs_*.csv` present.
 
 ## 5. Tweaking experiment parameters
 


### PR DESCRIPTION
## Summary
- Accept dataset names for `--input-folder` by resolving to the correct arc directory
- Document new `--input-folder` behaviour in README

## Testing
- `julia --project=package_dependencies/julia test/test_DCG.jl` *(failed: command not found)*
- `apt-get update` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c84bf174833080be2a1dd58e92c1